### PR TITLE
hide the overflow of steve

### DIFF
--- a/style.css
+++ b/style.css
@@ -174,6 +174,7 @@ html {
     grid-column: 1 / 2;
     grid-row: 11 / 12;
     position: relative;
+    overflow: hidden;
   }
 
   .instagram-container{


### PR DESCRIPTION
Apparently, during the shifting of the cards, all the cards contents gets to be as tall as they want for very brief moment, and the spline scene doesn't go back to being smaller. But because it's centered you can just hide the overflow at the parent level (which keeps a decent size throughout). 